### PR TITLE
add ibazel for script execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "lodash": "^4.17.15"
   },
   "devDependencies": {
+    "@bazel/ibazel": "^0.10.3",
     "@bazel/jasmine": "^0.37.0",
     "@bazel/typescript": "^0.37.0",
     "@types/node": "latest",
@@ -12,7 +13,7 @@
     "typescript": "^3.6.3"
   },
   "scripts": {
-    "build": "bazel build ...",
-    "test": "bazel test ..."
+    "build": "ibazel build //...",
+    "test": "ibazel test //..."
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@bazel/ibazel@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@bazel/ibazel/-/ibazel-0.10.3.tgz#2e2b8a1d3e885946eac41db2b1aa6801fb319887"
+  integrity sha512-v1nXbMTHVlMM4z4uWp6XiRoHAyUlYggF1SOboLLWRp0+D22kWixqArWqnozLw2mOtnxr97BdLjluWiho6A8Hjg==
+
 "@bazel/jasmine@^0.37.0":
   version "0.37.0"
   resolved "https://registry.yarnpkg.com/@bazel/jasmine/-/jasmine-0.37.0.tgz#8463e5d26cfcdb7f76865bf80c7b88a77b6eecb2"


### PR DESCRIPTION
Allows running in a typical NodeJS dev environment without first installing Bazel